### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "phpcompatibility/php-compatibility": "*",
     "phpunit/php-code-coverage": "^11",
     "phpunit/phpunit": "^11",
-    "roave/security-advisories": "dev-latest",
     "roots/wordpress": "~6.7",
     "slevomat/coding-standard": "~8.8",
     "squizlabs/php_codesniffer": "^3.2",


### PR DESCRIPTION
Because of https://github.com/Roave/SecurityAdvisories/pull/132